### PR TITLE
Fix networks / nodes link

### DIFF
--- a/content/md/en/docs/learn/architecture.md
+++ b/content/md/en/docs/learn/architecture.md
@@ -29,7 +29,7 @@ Some of the most important activities that are handled by core client services i
 
 - [Storage](/learn/state-transitions-and-storage/): The outer node persists the evolving state of a Substrate blockchain using a simple and highly efficient key-value storage layer.
 
-- [Peer-to-peer networking](/learn/node-and-network-types/): The outer node uses the Rust implementation of the [`libp2p` network stack](https://libp2p.io/) to communicate with other network participants.
+- [Peer-to-peer networking](/learn/networks-and-nodes/): The outer node uses the Rust implementation of the [`libp2p` network stack](https://libp2p.io/) to communicate with other network participants.
 
 - [Consensus](/learn/consensus/): The outer node communicates with other network participants to ensure they agree on the state of the blockchain.
 


### PR DESCRIPTION
 Fixed link in `architecture.md` under "Client outer node services".