### PR TITLE
Add outdated content banners to Tutorial docs

### DIFF
--- a/content/md/en/docs/tutorials/build-a-blockchain/add-trusted-nodes.md
+++ b/content/md/en/docs/tutorials/build-a-blockchain/add-trusted-nodes.md
@@ -7,6 +7,13 @@ keywords:
   - permission
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 This tutorial illustrates how you can start a small, standalone blockchain network with an **authority set** of private **validators**.
 
 As you learned in [Blockchain basics](/learn/blockchain-basics/), all blockchains require the nodes in the network to agree on the state of data at any specific point in time and this agreement about the state is called **consensus**.

--- a/content/md/en/docs/tutorials/build-a-blockchain/authorize-specific-nodes.md
+++ b/content/md/en/docs/tutorials/build-a-blockchain/authorize-specific-nodes.md
@@ -8,6 +8,13 @@ keywords:
   - restricted access
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 In [Add trusted nodes](/tutorials/build-a-blockchain/add-trusted-nodes/), you saw how to build a simple network with a known set of validator nodes.
 That tutorial illustrated a simplified version of a **permissioned network**.
 In a permissioned network, only **authorized nodes** are allowed to perform specific network activities.

--- a/content/md/en/docs/tutorials/build-a-blockchain/build-local-blockchain.md
+++ b/content/md/en/docs/tutorials/build-a-blockchain/build-local-blockchain.md
@@ -4,6 +4,15 @@ description: Compile, launch, and interact with a single local blockchain node i
 keywords:
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information and instructions. New Polkadot developer documentation is in the works!
+	</p>
+	<p>
+	 Meanwhile, please refer to the instructions on <a href="https://github.com/paritytech/polkadot-sdk-minimal-template">`minimal-template`</a> and <a href="https://github.com/paritytech/polkadot-sdk-solochain-template">`solochain-template` repositories</a> for the latest documentation and working code for this tutorial.
+	</p>
+</div>
+
 As you learned in [Blockchain basics](/learn/blockchain-basics/), a blockchain consists of decentralized computers—called nodes—to form a network.
 
 Substrate provides a flexible, open, and extensible development environment that allows you to design and build fully-customized blockchain nodes to suit your application or business model needs.

--- a/content/md/en/docs/tutorials/build-a-blockchain/index.md
+++ b/content/md/en/docs/tutorials/build-a-blockchain/index.md
@@ -10,6 +10,14 @@ keywords:
   - generate keys
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains a list of tutorials with potentially outdated information 
+  and instructions. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content and 
+  links on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 The **Build a blockchain** tutorials illustrate the basics for working with Substrate-based blockchain nodes, including how to make nodes communicate with each other in a network of peers and how to collect metrics about node operations.
 In general, you should complete the tutorials in the order listed because they lay the foundation for trying later tutorials or performing more complex tasks.
 Later tutorials reinforce or expand on the basic topics you learn in the Get started tutorials.

--- a/content/md/en/docs/tutorials/build-a-blockchain/monitor-node-metrics.md
+++ b/content/md/en/docs/tutorials/build-a-blockchain/monitor-node-metrics.md
@@ -7,6 +7,13 @@ keywords:
   - node operations
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 Substrate exposes metrics about the operation of your network.
 For example, you can collect information about how many peers your node is connected to, how much memory your node is using, and the number of blocks being produced.
 To capture and visualize the metrics that Substrate nodes expose, you can configure and use tools like [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/).

--- a/content/md/en/docs/tutorials/build-a-blockchain/simulate-network.md
+++ b/content/md/en/docs/tutorials/build-a-blockchain/simulate-network.md
@@ -4,6 +4,13 @@ description: Start a private blockchain network using predefined accounts as aut
 keywords:
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 This tutorial provides a basic introduction to how you can start a private blockchain network with an **authority set** of private **validators**.
 
 The Substrate node template uses an authority consensus model that limits block production to a rotating list of authorized accounts.

--- a/content/md/en/docs/tutorials/build-a-blockchain/upgrade-a-running-network.md
+++ b/content/md/en/docs/tutorials/build-a-blockchain/upgrade-a-running-network.md
@@ -6,6 +6,13 @@ keywords:
   - runtime upgrade
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 Unlike many blockchains, the Substrate development framework supports **forkless upgrades** to the runtime that is the core of the blockchain.
 Most blockchain projects require a [hard fork](/reference/glossary/#fork) of the code base to support ongoing development of new features or enhancements to existing features.
 With Substrate, you can deploy enhanced runtime capabilities—including breaking changes—without a hard fork.

--- a/content/md/en/docs/tutorials/build-a-parachain/acquire-a-testnet-slot.md
+++ b/content/md/en/docs/tutorials/build-a-parachain/acquire-a-testnet-slot.md
@@ -8,6 +8,13 @@ keywords:
   - relay chain
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 This tutorial demonstrates how you can deploy a parachain on a public test network, such as the [Rococo](https://wiki.polkadot.network/docs/build-pdk#rococo-testnet) test network.
 Public test networks have a higher bar to entry than a private network, but represent an important step in preparing a parachain project to move into a production network. 
 

--- a/content/md/en/docs/tutorials/build-a-parachain/connect-a-local-parachain.md
+++ b/content/md/en/docs/tutorials/build-a-parachain/connect-a-local-parachain.md
@@ -9,6 +9,13 @@ keywords:
   - chain specification
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 This tutorial illustrates how to reserve a parachain identifier with a local relay chain and how to connect a local parachain to that relay chain.
 
 ## Tutorial objectives

--- a/content/md/en/docs/tutorials/build-a-parachain/index.md
+++ b/content/md/en/docs/tutorials/build-a-parachain/index.md
@@ -9,6 +9,14 @@ keywords:
   - Polkadot
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains a list of tutorials with potentially outdated information 
+  and instructions. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content and 
+  links on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 The **Build a parachain** tutorials delve into more advanced topics for moving beyond solo chain development, including how to connect your chain to other chains.
 
 - [Prepare a local relay chain](/tutorials/build-a-parachain/prepare-a-local-relay-chain/) helps you prepare a local relay chain to use in testing a local parachain.

--- a/content/md/en/docs/tutorials/build-a-parachain/open-message-passing-channels.md
+++ b/content/md/en/docs/tutorials/build-a-parachain/open-message-passing-channels.md
@@ -9,6 +9,13 @@ keywords:
   - parachain
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 In the Polkadot ecosystem, chains can communicate with each other by passing messages over secure channels.
 There are three main communication channels:
 

--- a/content/md/en/docs/tutorials/build-a-parachain/prepare-a-local-relay-chain.md
+++ b/content/md/en/docs/tutorials/build-a-parachain/prepare-a-local-relay-chain.md
@@ -16,6 +16,13 @@ keywords:
   - local
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 This tutorial illustrates how to configure a local relay chain.
 The local relay chain is required to set up a local testing environment that a test parachain node can connect to.
 

--- a/content/md/en/docs/tutorials/build-a-parachain/transfer-assets-with-xcm.md
+++ b/content/md/en/docs/tutorials/build-a-parachain/transfer-assets-with-xcm.md
@@ -9,6 +9,13 @@ keywords:
   - cross consensus
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 In [Open message passing channels](/tutorials/build-a-parachain/open-message-passing-channels), you saw how to open a two-way communication channel between chains by sending messages to the relay chain.
 You can use a similar strategy to send messages that allow a local chain to manage an account on a remote chain.
 In this tutorial, parachain B transfers assets into the sovereign account on the relay chain for parachain A.

--- a/content/md/en/docs/tutorials/build-application-logic/add-a-pallet.md
+++ b/content/md/en/docs/tutorials/build-application-logic/add-a-pallet.md
@@ -10,6 +10,13 @@ keywords:
   - configuration
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 As you saw in [Build a local blockchain](/tutorials/build-a-blockchain/build-local-blockchain/), the [Substrate node template](https://github.com/substrate-developer-hub/substrate-node-template) provides a working **runtime** that includes some default FRAME development modules—**pallets**—to get you started building a custom blockchain.
 
 This tutorial introduces the basic steps for adding a new pallet to the runtime for the node template.

--- a/content/md/en/docs/tutorials/build-application-logic/add-offchain-workers.md
+++ b/content/md/en/docs/tutorials/build-application-logic/add-offchain-workers.md
@@ -13,6 +13,13 @@ keywords:
 
 <div class="warning">
 	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
+<div class="warning">
+	<p>
 	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
 	</p>
 	<p>

--- a/content/md/en/docs/tutorials/build-application-logic/index.md
+++ b/content/md/en/docs/tutorials/build-application-logic/index.md
@@ -4,6 +4,14 @@ description: Demonstrates how you can add pallets to customize the Substrate run
 keywords:
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains a list of tutorials with potentially outdated information 
+  and instructions. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content and 
+  links on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 The **Build application logic** tutorials focus on how you can customize the runtime using pallets, including how to add simple and complex pallets to the runtime and how to use pallets in combination with smart contracts.
 You'll learn how to:
 

--- a/content/md/en/docs/tutorials/build-application-logic/publish-custom-pallets.md
+++ b/content/md/en/docs/tutorials/build-application-logic/publish-custom-pallets.md
@@ -4,6 +4,13 @@ description: Suggests how you can publish custom pallets and crates to make them
 keywords:
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 As a blockchain builder or parachain developer, you have access to a large library of specialized pallets that you can assemble to customize your runtime to suite your specific project goals.
 To get a general sense of the number of the predefined pallets currently available, explore the Substrate [FRAME repository](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/frame).
 The selection of pallets available and the use cases they address is continuously evolving, including with many contributions from community members.

--- a/content/md/en/docs/tutorials/build-application-logic/specify-the-origin-for-a-call.md
+++ b/content/md/en/docs/tutorials/build-application-logic/specify-the-origin-for-a-call.md
@@ -7,6 +7,13 @@ keywords:
   - origins
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 In [Add a pallet to the runtime](/tutorials/build-application-logic/add-a-pallet), you added functions from `pallet_nicks` to the [Substrate node template](https://github.com/substrate-developer-hub/substrate-node-template) runtime.
 
 The Nicks pallet allows blockchain users to pay a deposit to reserve a nickname for an account they control.

--- a/content/md/en/docs/tutorials/build-application-logic/use-macros-in-a-custom-pallet.md
+++ b/content/md/en/docs/tutorials/build-application-logic/use-macros-in-a-custom-pallet.md
@@ -3,6 +3,12 @@ title: Use macros in a custom pallet
 description: Create a custom pallet for a Substrate runtime using a skeleton of FRAME macros.
 keywords:
 ---
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information 
+  and instructions. Reading it might still be useful, yet we suggest taking it with a grain of salt. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content on this page will be updated. Thanks for your patience!
+	</p>
+</div>
 
 This tutorial illustrates how to create a custom pallet for a Substrate
 runtime using **macros** that are part of the [FRAME](/reference/frame-macros/) development environment.

--- a/content/md/en/docs/tutorials/collectibles-workshop/index.md
+++ b/content/md/en/docs/tutorials/collectibles-workshop/index.md
@@ -6,6 +6,14 @@ keywords:
   - runtime
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains a list of tutorials with potentially outdated information 
+  and instructions. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content and 
+  links on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 The Substrate Developer Hub provides self-paced workshops with content and coding challenges to help you learn about building blockchains and decentralized applications using Substrate, Rust, and related tools.
 
 As you progress through the workshops, you’ll learn basic concepts, see examples of what to do, and test your knowledge by converting what you’ve learned into working code.

--- a/content/md/en/docs/tutorials/index.md
+++ b/content/md/en/docs/tutorials/index.md
@@ -4,6 +4,14 @@ description:
 keywords:
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains a list of tutorials with potentially outdated information 
+  and instructions. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content and 
+  links on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 If you are someone who likes to learn by doing, the Substrate tutorials are a great place to start your journey.
 Tutorials don't provide much background about _why_ you are performing certain steps or explain the coding details.
 Instead, the tutorials give you hands-on experience performing the tasks essential to building your own blockchain and focus on ensuring a successful result.

--- a/content/md/en/docs/tutorials/integrate-with-tools/index.md
+++ b/content/md/en/docs/tutorials/integrate-with-tools/index.md
@@ -4,6 +4,14 @@ description: Demonstrates use cases for tools that enable you to connect to and 
 keywords:
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains a list of tutorials with potentially outdated information 
+  and instructions. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content and 
+  links on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 The **Integrate with tools** tutorials highlight tools and node extensions that enable you to deploy nodes that can integrate with other systems and how to use additional ecosystem tools that allow you to access, synchronize, and interact with information your own or other blockchains.
 
 - [Integrate a light client node](/tutorials/integrate-with-tools/integrate-a-light-client-node/) describes how you can use the Substrate Connect light client node to synchronize and interact with a Substrate chain from a browser.

--- a/content/md/en/docs/tutorials/smart-contracts/index.md
+++ b/content/md/en/docs/tutorials/smart-contracts/index.md
@@ -5,6 +5,14 @@ keywords:
   - smart contracts
 ---
 
+<div class="warning">
+	<p>
+	<strong>⚠️ WARNING:</strong> This page contains a list of tutorials with potentially outdated information 
+  and instructions. When the new [Polkadot developer documentation](https://forum.polkadot.network/t/decentralized-futures-ecosystem-devrel-team-for-polkadot-by-papermoon/5811) is published, the content and 
+  links on this page will be updated. Thanks for your patience!
+	</p>
+</div>
+
 The **Develop smart contracts** tutorials guide you through how you can use [the ink! programming language](https://use.ink) to build smart contracts that run on a Substrate-based blockchain.
 
 The tutorials in this section use a preconfigured


### PR DESCRIPTION
Warning note on all tutorial index pages and most of the content pages that have outdated instructions.