### PR TITLE
Meta Depreaction

### DIFF
--- a/.netlify/_redirects
+++ b/.netlify/_redirects
@@ -1,6 +1,6 @@
 # Redirects from what the browser requests to what we serve
 
-/rustdocs                   https://paritytech.github.io/substrate/master/sc_service/ 301!
+/rustdocs                   https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/index.html 301!
 
 /how-to-guides              /reference/                                               301!
 

--- a/content/config/nav.yaml
+++ b/content/config/nav.yaml
@@ -1,4 +1,5 @@
 menu:
+  - polkadot-sdk
   - quick-start
   - learn
   - install
@@ -10,8 +11,12 @@ menu:
   - reference
   - community
 
+polkadot-sdk:
+  title: Substrate -> Polkadot SDK
+  url: /polkadot-sdk/
+
 quick-start:
-  title: Quick start
+  title: Quick start (Deprecated)
   url: /quick-start/
   pages:
     - title: Substrate at a glance
@@ -24,7 +29,7 @@ quick-start:
       url: /quick-start/modify-the-runtime/
 
 learn:
-  title: Learn
+  title: Learn (Deprecated)
   url: /learn/
   pages:
     - title: Welcome to Substrate
@@ -69,7 +74,7 @@ learn:
       url: /learn/xcm-communication/
 
 install:
-  title: Install
+  title: Install (Deprecated)
   url: /install/
   pages:
     - title: Rust toolchain
@@ -84,7 +89,7 @@ install:
       url: /install/developer-tools/
     - title: Troubleshoot Rust issues
       url: /install/troubleshoot-rust-issues/
-  
+
 #design:
  # title: Design
  # url: /design/
@@ -106,7 +111,7 @@ install:
   #- title: Economic models
   #url: /design/economic-models/
 build:
-  title: Build
+  title: Build (Deprecated)
   url: /build/
   pages:
     - title: Smart contracts
@@ -143,7 +148,7 @@ build:
     #url: /build/executor/
 
 test:
-  title: Test
+  title: Test (Deprecated)
   url: /test/
   pages:
     - title: Unit test
@@ -156,9 +161,9 @@ test:
       url: /test/simulate-parachains/
     - title: Check runtime
       url: /test/check-runtime/
-      
+
 deploy:
-  title: Deploy
+  title: Deploy (Deprecated)
   url: /deploy/
   pages:
     - title: Prepare to deploy
@@ -174,7 +179,7 @@ deploy:
 #   - title: Launch a parachain
 #     url: /deploy/launch-a-parachain/
 maintain:
-  title: Maintain
+  title: Maintain (Deprecated)
   url: /maintain/
   pages:
     - title: Monitor
@@ -191,7 +196,7 @@ maintain:
 #     url: /maintain/data-migration/
 
 tutorials:
-  title: Tutorials
+  title: Tutorials (Deprecated)
   url: /tutorials/
   pages:
     - title: Build a blockchain
@@ -282,7 +287,7 @@ tutorials:
 #         url: /tutorials/integrate-with-tools/access-evm-accounts/
 
 reference:
-  title: Reference
+  title: Reference (Deprecated)
   url: /reference/
   pages:
     - title: Rust API
@@ -335,7 +340,7 @@ reference:
       url: /reference/how-to-guides/
 
 community:
-  title: Community
+  title: Community (Deprecated)
   url: /community/
   pages:
     - title: Content style guide

--- a/content/config/nav.yaml
+++ b/content/config/nav.yaml
@@ -16,7 +16,7 @@ polkadot-sdk:
   url: /polkadot-sdk/
 
 quick-start:
-  title: Quick start (Deprecated)
+  title: Quick start
   url: /quick-start/
   pages:
     - title: Substrate at a glance
@@ -29,7 +29,7 @@ quick-start:
       url: /quick-start/modify-the-runtime/
 
 learn:
-  title: Learn (Deprecated)
+  title: Learn
   url: /learn/
   pages:
     - title: Welcome to Substrate
@@ -74,7 +74,7 @@ learn:
       url: /learn/xcm-communication/
 
 install:
-  title: Install (Deprecated)
+  title: Install
   url: /install/
   pages:
     - title: Rust toolchain
@@ -111,7 +111,7 @@ install:
   #- title: Economic models
   #url: /design/economic-models/
 build:
-  title: Build (Deprecated)
+  title: Build
   url: /build/
   pages:
     - title: Smart contracts
@@ -148,7 +148,7 @@ build:
     #url: /build/executor/
 
 test:
-  title: Test (Deprecated)
+  title: Test
   url: /test/
   pages:
     - title: Unit test
@@ -163,7 +163,7 @@ test:
       url: /test/check-runtime/
 
 deploy:
-  title: Deploy (Deprecated)
+  title: Deploy
   url: /deploy/
   pages:
     - title: Prepare to deploy
@@ -179,7 +179,7 @@ deploy:
 #   - title: Launch a parachain
 #     url: /deploy/launch-a-parachain/
 maintain:
-  title: Maintain (Deprecated)
+  title: Maintain
   url: /maintain/
   pages:
     - title: Monitor
@@ -196,7 +196,7 @@ maintain:
 #     url: /maintain/data-migration/
 
 tutorials:
-  title: Tutorials (Deprecated)
+  title: Tutorials
   url: /tutorials/
   pages:
     - title: Build a blockchain
@@ -287,7 +287,7 @@ tutorials:
 #         url: /tutorials/integrate-with-tools/access-evm-accounts/
 
 reference:
-  title: Reference (Deprecated)
+  title: Reference
   url: /reference/
   pages:
     - title: Rust API
@@ -340,7 +340,7 @@ reference:
       url: /reference/how-to-guides/
 
 community:
-  title: Community (Deprecated)
+  title: Community
   url: /community/
   pages:
     - title: Content style guide

--- a/content/config/nav.yaml
+++ b/content/config/nav.yaml
@@ -12,7 +12,7 @@ menu:
   - community
 
 polkadot-sdk:
-  title: Substrate -> Polkadot SDK
+  title: Substrate to Polkadot SDK
   url: /polkadot-sdk/
 
 quick-start:

--- a/content/md/en/docs/build/genesis-configuration.md
+++ b/content/md/en/docs/build/genesis-configuration.md
@@ -5,7 +5,7 @@ keywords:
 ---
 
 <div class="warning">
-  <strong>⚠️ WARNING:</strong> This page contains outdated information. Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/frame_support/pallet_macros/attr.genesis_build.html">Rust docs</a> for the most up-to-date documentation on this topic.
+  Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/frame_support/pallet_macros/attr.genesis_build.html">Rust docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 
@@ -19,7 +19,7 @@ As you learned in [Chain specification](/build/chain-spec/), the chain specifica
 However, the chain specification doesn't create the storage items that get initialized when you start a node.
 Instead, the storage items are defined in the pallets included in the runtime as described in [Runtime storage](/build/runtime-storage/).
 
-After you create storage items for the runtime, you can choose whether they should be set to some initial value as part of the genesis configuration and included in the genesis block.  
+After you create storage items for the runtime, you can choose whether they should be set to some initial value as part of the genesis configuration and included in the genesis block.
 To specify the storage items that you want to set an initial state for, Substrate provides two specialized FRAME attribute macros.
 
 The macros you can use to initialize storage items as part of the genesis configuration for a chain are:
@@ -120,12 +120,17 @@ All of the `GenesisConfig` types for the pallets that included in the constructi
 The aggregated `RuntimeGenesisConfig` implements the [`BuildStorage`](https://paritytech.github.io/substrate/master/sp_runtime/trait.BuildStorage.html) trait to build all of the initial storage items for the runtime.
 For example, the node template runtime builds storage items for the following pallets that have a `RuntimeGenesisConfig` specified by default:
 
-- [System pallet](#system-pallet)
-- [Aura pallet](#aura-pallet)
-- [Grandpa pallet](#grandpa-pallet)
-- [Balances pallet](#balances-pallet)
-- [TransactionPayment pallet](#transactionpayment-pallet)
-- [Sudo pallet](#sudo-pallet)
+- [Configure a simple storage value](#configure-a-simple-storage-value)
+  - [Configure macros in the pallet](#configure-macros-in-the-pallet)
+  - [Configure the chain specification](#configure-the-chain-specification)
+- [Adding genesis configuration to the runtime](#adding-genesis-configuration-to-the-runtime)
+  - [System pallet](#system-pallet)
+  - [Aura pallet](#aura-pallet)
+  - [Grandpa pallet](#grandpa-pallet)
+  - [Balances pallet](#balances-pallet)
+  - [TransactionPayment pallet](#transactionpayment-pallet)
+  - [Sudo pallet](#sudo-pallet)
+- [Initialize storage items within a pallet](#initialize-storage-items-within-a-pallet)
 
 ### System pallet
 

--- a/content/md/en/docs/build/origins.md
+++ b/content/md/en/docs/build/origins.md
@@ -6,7 +6,7 @@ keywords:
 ---
 
 <div class="warning">
-  <strong>⚠️ WARNING:</strong> This page contains outdated information. Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_origin/index.html">Rust docs</a> for the most up-to-date documentation on this topic.
+  Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_origin/index.html">Rust docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 The runtime origin is used by dispatchable functions to check where a call has come from.

--- a/content/md/en/docs/build/pallet-coupling.md
+++ b/content/md/en/docs/build/pallet-coupling.md
@@ -7,12 +7,7 @@ keywords:
 ---
 
 <div class="warning">
-	<p>
-	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
-	</p>
-	<p>
-	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_pallet_coupling/index.html">`polkadot-sdk-docs` crate</a> for the most up-to-date documentation on this topic.
-	</p>
+	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_pallet_coupling/index.html">Rust Docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 The term **coupling** is often used to describe the degree to which two software modules depend on each other.

--- a/content/md/en/docs/build/remote-procedure-calls.md
+++ b/content/md/en/docs/build/remote-procedure-calls.md
@@ -7,7 +7,7 @@ keywords:
 ---
 
 <div class="warning">
-  <strong>⚠️ WARNING:</strong> This page may contain outdated information. Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/custom_runtime_api_rpc/index.html">Rust docs</a> for the most up-to-date documentation on this topic.
+  Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/custom_runtime_api_rpc/index.html">Rust docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 Remote procedure calls, or RPC methods, are a way for an external program—for example, a browser or front-end application—to communicate with a Substrate node.

--- a/content/md/en/docs/build/remote-procedure-calls.md
+++ b/content/md/en/docs/build/remote-procedure-calls.md
@@ -6,6 +6,10 @@ keywords:
   - frontend
 ---
 
+<div class="warning">
+  <strong>⚠️ WARNING:</strong> This page may contain outdated information. Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/custom_runtime_api_rpc/index.html">Rust docs</a> for the most up-to-date documentation on this topic.
+</div>
+
 Remote procedure calls, or RPC methods, are a way for an external program—for example, a browser or front-end application—to communicate with a Substrate node.
 In general, these methods enable an RPC client to connect to an RPC server endpoint to request some type of service.
 For example, you might use an RPC method to read a stored value, submit a transaction, or request information about the chain a node is connected to.

--- a/content/md/en/docs/examples/quickstart/index.html
+++ b/content/md/en/docs/examples/quickstart/index.html
@@ -20,36 +20,36 @@
       }
     </style>
   </head>
-  
+
   <body>
     <main role="main" class="container">
     <h1 style="font-family: sans-serif; font-weight: 500;">Display an account balance</h1>
       <p style="font-family: sans-serif;">Enter a development account address, then click <b>Get Balance</b>.</p>
-  
+
       <input type="text" size="58" id="account_address"/>
       <input type="button" onclick="GetBalance()" value="Get Balance">
       <p class="output">Balance: <span id="polkadot-balance">Not Connected</span></p>
     </main>
-  
+
     <script src="https://unpkg.com/@polkadot/util/bundle-polkadot-util.js"></script>
     <script src="https://unpkg.com/@polkadot/util-crypto/bundle-polkadot-util-crypto.js"></script>
     <script src="https://unpkg.com/@polkadot/types/bundle-polkadot-types.js"></script>
     <script src="https://unpkg.com/@polkadot/api/bundle-polkadot-api.js"></script>
-  
+
     <script>
       async function GetBalance() {
         const ADDR = '5Gb6Zfe8K8NSKrkFLCgqs8LUdk7wKweXM5pN296jVqDpdziR';
-  
+
         const { WsProvider, ApiPromise } = polkadotApi;
         const wsProvider = new WsProvider('ws://127.0.0.1:9944');
         const polkadot = await ApiPromise.create({ provider: wsProvider });
-  
+
         let polkadotBalance = document.getElementById("polkadot-balance");
         const x = document.getElementById("account_address").value;
         const { data: balance } = await polkadot.query.system.account(x);
-        
+
         polkadotBalance.innerText = balance.free;
-      }  
+      }
     </script>
   </body>
   </html>

--- a/content/md/en/docs/learn/offchain-operations.md
+++ b/content/md/en/docs/learn/offchain-operations.md
@@ -5,12 +5,7 @@ keywords:
 ---
 
 <div class="warning">
-	<p>
-	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
-	</p>
-	<p>
-	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_offchain_workers/index.html">`polkadot-sdk-docs` crate</a> for the most up-to-date documentation on this topic.
-	</p>
+	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_offchain_workers/index.html">Rust Docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 There are many use cases where you might want to query data from an offchain source or process data without using on-chain resources before updating the on-chain state.

--- a/content/md/en/docs/learn/runtime-development.md
+++ b/content/md/en/docs/learn/runtime-development.md
@@ -139,7 +139,6 @@ pub mod pallet {
  // Declare the pallet type
  // This is a placeholder to implement traits and methods.
  #[pallet::pallet]
- #[pallet::generate_store(pub(super) trait Store)]
  pub struct Pallet<T>(_);
 
  // Add the runtime configuration trait

--- a/content/md/en/docs/polkadot-sdk/index.md
+++ b/content/md/en/docs/polkadot-sdk/index.md
@@ -35,5 +35,5 @@ Below, you can find a number of replacement resources to learn more about Polkad
 - [Polkadot Wiki](https://wiki.polkadot.network/docs/build-guide)
 - [Polkadot Developers](https://github.com/polkadot-developers/)
 - [Polkadot Blockchain Academy](https://polkadot.com/blockchain-academy)
-- Polkadot Ecosystem Documentation by Papermoon (Work in progress)
 - [Polkadot SDK Rust Docs](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/index.html)
+- Polkadot Ecosystem Documentation by Papermoon (Work in progress, see progress [here](https://forum.polkadot.network/t/decentralized-futures-papermoon-first-updates/9265))

--- a/content/md/en/docs/polkadot-sdk/index.md
+++ b/content/md/en/docs/polkadot-sdk/index.md
@@ -22,7 +22,9 @@ This transition gave birth to a new vision in which these tools are seen from le
 
 Most impacted in this transition is **Substrate**, and part of this impact is gradual deprecation of
 this website. The content in this website is no longer maintained, and will be gradually moved to a
-new home. Consider the following resources as primary sources of information.
+new home. Consider the [resources below](#alternative-resources) as primary sources of information.
+
+> You may still access the old content of this website in the navbar, but be aware of the fact that some content might not be up to date.
 
 Note that **this does not impact the development of Substrate as a framework**. Substrate, as a framework, is still being maintained with full steam as a part of polkadot-sdk, and retains its full ability to be used to build both [standalone blockchains](https://github.com/paritytech/polkadot-sdk-solochain-template), or [Polkadot powered parachains](https://github.com/paritytech/polkadot-sdk-parachain-template).
 

--- a/content/md/en/docs/polkadot-sdk/index.md
+++ b/content/md/en/docs/polkadot-sdk/index.md
@@ -1,0 +1,37 @@
+---
+title: Polkadot SDK
+description:
+keywords:
+  - polkadot-sdk
+---
+
+
+## Substrate to Polkadot SDK
+
+In [May
+2023](https://forum.polkadot.network/t/psa-parity-is-currently-working-on-merging-the-polkadot-stack-repositories-into-one-single-repository/2883),
+Parity Technologies started moving 3 repositories of
+[`substrate`](https://github.com/paritytech/substrate),
+[`polkadot`](https://github.com/paritytech/polkadot), and
+[`cumulus`](https://github.com/paritytech/cumulus), formerly independent in development and
+branding, under one mew mono-repo called
+[`polkadot-sdk`](https://github.com/paritytech/polkadot-sdk). Consequently, the [runtimes of the
+Polkadot and Kusama relay chains, and their system chain](https://github.com/polkadot-fellows/runtimes) were moved to be maintained by the [Polkadot fellowship](polkadot-fellows.github.io/dashboard/).
+
+This transition gave birth to a new vision in which these tools are seen from lense of being part of `polkadot-sdk`, while still being independently useful.
+
+Most impacted in this transition is **Substrate**, and part of this impact is gradual deprecation of
+this website. The content in this website is no longer maintained, and will be gradually moved to a
+new home. Consider the following resources as primary sources of information.
+
+Note that **this does not impact the development of Substrate as a framework**. Substrate, as a framework, is still being maintained with full steam as a part of polkadot-sdk, and retains its full ability to be used to build both [standalone blockchains](https://github.com/paritytech/polkadot-sdk-solochain-template), or [Polkadot powered parachains](https://github.com/paritytech/polkadot-sdk-parachain-template).
+
+## Alternative Resources
+
+Below, you can find a number of replacement resources to learn more about Polkadot SDK:
+
+- [Polkadot Wiki](https://wiki.polkadot.network/)
+- [Polkadot Developers](https://github.com/polkadot-developers/)
+- [Polkadot Blockchain Academy](https://academy.polkadot.network/)
+- [Polkadot Ecosystem Documentation by Papermoon](https://wiki.polkadot.network/)
+- [Polkadot SDK Rust Docs](https://wiki.polkadot.network/)

--- a/content/md/en/docs/reference/frame-macros.md
+++ b/content/md/en/docs/reference/frame-macros.md
@@ -256,15 +256,6 @@ For example:
 pub struct Pallet<T>(_);
 ```
 
-This macro can generate the `Store` trait to contain an associated type for each storage item if you provide the `#[pallet::generate_store($vis trait Store)]` attribute macro.
-
-For example:
-
-```rust
-#[pallet::pallet]
-pub struct Pallet<T>(_);
-```
-
 For more information about working with storage and this macro, see the [macro expansion](https://paritytech.github.io/substrate/master/frame_support/attr.pallet.html#macro-expansion-1) added to the `struct Pallet<T>` definition.
 
 ### #[pallet::without\_storage\_info]
@@ -279,7 +270,6 @@ To use it, add the `#[pallet::without_storage_info]` attribute to the pallet str
 
 ```rust
 #[pallet::pallet]
-#[pallet::generate_store(pub(super) trait Store)]
 #[pallet::without_storage_info]
 pub struct Pallet<T>(_);
 ```

--- a/content/md/en/docs/reference/frame-macros.md
+++ b/content/md/en/docs/reference/frame-macros.md
@@ -4,7 +4,7 @@ description:
 keywords:
 ---
 <div class="warning">
-  <strong>⚠️ WARNING:</strong> This section contains outdated information. Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/frame_support/attr.pallet.html">Rust docs</a> for the most up-to-date documentation on this topic.
+  Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/frame_support/attr.pallet.html">Rust docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 Substrate uses customized [Rust macros](https://doc.rust-lang.org/book/ch19-06-macros.html) to generate code and aggregate the logic from the pallets you implement for a runtime.

--- a/content/md/en/docs/reference/how-to-guides/offchain-workers/index.md
+++ b/content/md/en/docs/reference/how-to-guides/offchain-workers/index.md
@@ -5,12 +5,7 @@ keywords:
 ---
 
 <div class="warning">
-	<p>
-	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
-	</p>
-	<p>
-	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_offchain_workers/index.html">`polkadot-sdk-docs` crate</a> for the most up-to-date documentation on this topic.
-	</p>
+	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_offchain_workers/index.html">Rust Docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 The _How-to_ guides in the _Offchain workers_ category illustrate common use cases for offchain operations.

--- a/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-http-requests.md
+++ b/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-http-requests.md
@@ -10,12 +10,7 @@ keywords:
 ---
 
 <div class="warning">
-	<p>
-	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
-	</p>
-	<p>
-	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_offchain_workers/index.html">`polkadot-sdk-docs` crate</a> for the most up-to-date documentation on this topic.
-	</p>
+	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_offchain_workers/index.html">Rust Docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 Because most blockchains can't access data that's hosted on servers outside of their own network, they typically use external third-party services—**oracles**—to pull information in from or push information out to locations that are outside of the network.

--- a/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-indexing.md
+++ b/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-indexing.md
@@ -8,12 +8,7 @@ keywords:
 ---
 
 <div class="warning">
-	<p>
-	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
-	</p>
-	<p>
-	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_offchain_workers/index.html">`polkadot-sdk-docs` crate</a> for the most up-to-date documentation on this topic.
-	</p>
+	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_offchain_workers/index.html">Rust Docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 This guide will step you through how to pass data from an extrinsic to an offchain worker without writing to storage.

--- a/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-local-storage.md
+++ b/content/md/en/docs/reference/how-to-guides/offchain-workers/offchain-local-storage.md
@@ -9,12 +9,7 @@ keywords:
 ---
 
 <div class="warning">
-	<p>
-	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
-	</p>
-	<p>
-	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_offchain_workers/index.html">`polkadot-sdk-docs` crate</a> for the most up-to-date documentation on this topic.
-	</p>
+	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_offchain_workers/index.html">Rust Docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 This guide will teach you how to use an offchain worker to save retrieved data in local storage for future access.

--- a/content/md/en/docs/reference/how-to-guides/pallet-design/use-loose-coupling.md
+++ b/content/md/en/docs/reference/how-to-guides/pallet-design/use-loose-coupling.md
@@ -5,12 +5,7 @@ keywords:
 ---
 
 <div class="warning">
-	<p>
-	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
-	</p>
-	<p>
-	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_pallet_coupling/index.html">`polkadot-sdk-docs` crate</a> for the most up-to-date documentation on this topic.
-	</p>
+	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_pallet_coupling/index.html">Rust Docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 This guide demonstrates how to reuse a function or type from one pallet in another pallet using a technique called **loose coupling**.

--- a/content/md/en/docs/reference/how-to-guides/pallet-design/use-tight-coupling.md
+++ b/content/md/en/docs/reference/how-to-guides/pallet-design/use-tight-coupling.md
@@ -5,12 +5,7 @@ keywords:
 ---
 
 <div class="warning">
-	<p>
-	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
-	</p>
-	<p>
-	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_pallet_coupling/index.html">`polkadot-sdk-docs` crate</a> for the most up-to-date documentation on this topic.
-	</p>
+	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_pallet_coupling/index.html">Rust Docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 Tight coupling two pallets is a technique to write pallets that re-use types and methods from an existing pallet.

--- a/content/md/en/docs/reference/xcm-reference.md
+++ b/content/md/en/docs/reference/xcm-reference.md
@@ -9,12 +9,7 @@ keywords:
 ---
 
 <div class="warning">
-	<p>
-	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
-	</p>
-	<p>
-	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/xcm/index.html">`polkadot-sdk-docs` crate</a> for the most up-to-date documentation on this topic.
-	</p>
+	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/xcm/index.html">Rust Docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 This section provides reference information for the cross-consensus message (XCM) format.

--- a/content/md/en/docs/tutorials/build-application-logic/add-offchain-workers.md
+++ b/content/md/en/docs/tutorials/build-application-logic/add-offchain-workers.md
@@ -12,12 +12,7 @@ keywords:
 ---
 
 <div class="warning">
-	<p>
-	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
-	</p>
-	<p>
-	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_offchain_workers/index.html">`polkadot-sdk-docs` crate</a> for the most up-to-date documentation on this topic.
-	</p>
+	 Please refer to the <a href="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/frame_offchain_workers/index.html">Rust Docs</a> for the most up-to-date documentation on this topic.
 </div>
 
 This tutorial illustrates how to modify a pallet to include an offchain worker and configure the pallet and runtime to enable the offchain worker to submit transactions that update the on-chain state.

--- a/content/md/en/docs/tutorials/collectibles-workshop/03-create-pallet.md
+++ b/content/md/en/docs/tutorials/collectibles-workshop/03-create-pallet.md
@@ -3,6 +3,8 @@ title: Create a new pallet
 tutorial: 1
 ---
 
+> ⚠️ This tutorial is out-of-date any may not work as intended. Please refer to [`Polkadot SDK Docs`](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/guides/your_first_pallet/index.html) for up-to-date information.
+
 In this workshop, you'll learn how to create a custom Substrate module-called a pallet-that's going to contain the code for your application-specific blockchain.
 Pallets are built using FRAME libraries and the Rust programming language.
 FRAME includes a lot of specialized macros that make it easy to compose the application logic in a reusable container.
@@ -104,14 +106,14 @@ To update the manifest for the collectibles project:
    
    ```toml
    [dependencies]
-   frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk.git", branch = "polkadot-v1.0.0"}
-   frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/polkadot-sdk.git", branch = "polkadot-v1.0.0" }
+   frame-support = { default-features = false, version = "36.0.0" }
+   frame-system = { default-features = false, version = "36.0.0" }
    ```
 
 3. Add `codec` and `scale-info` to the dependencies.
    
    ```toml
-   codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive",] }
+   codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
    scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
    ```
 
@@ -152,7 +154,6 @@ The next step is to prepare a set of common macros to serve as scaffolding for y
         use frame_system::pallet_prelude::*;
 
         #[pallet::pallet]
-        #[pallet::generate_store(pub(super) trait Store)]
         pub struct Pallet<T>(_);
 
         #[pallet::config]

--- a/content/md/en/docs/tutorials/integrate-with-tools/explore-sidecar-endpoints.md
+++ b/content/md/en/docs/tutorials/integrate-with-tools/explore-sidecar-endpoints.md
@@ -5,12 +5,7 @@ keywords:
 ---
 
 <div class="warning">
-	<p>
-	<strong>⚠️ WARNING:</strong> This page contains potentially outdated information. Reading it might still be useful, yet we suggest taking it with a grain of salt.
-	</p>
-	<p>
 	 Please refer to the <a href="https://paritytech.github.io/substrate-api-sidecar/dist/">Sidecar docs</a>, the <a href="https://github.com/paritytech/substrate-api-sidecar?tab=readme-ov-file#note">README</a> and the <a href="https://github.com/paritytech/substrate-api-sidecar/tree/master/guides">guides folder</a> for the most up-to-date documentation on this topic.
-	</p>
 </div>
 
 The Substrate [sidecar](https://github.com/paritytech/substrate-api-sidecar) service provides a REST API for interacting with Substrate blockchain nodes built using FRAME.

--- a/content/md/en/docs/tutorials/integrate-with-tools/explore-sidecar-endpoints.md
+++ b/content/md/en/docs/tutorials/integrate-with-tools/explore-sidecar-endpoints.md
@@ -94,7 +94,7 @@ To download and install `sidecar`:
 
 To use the predefined API collection for `sidecar`:
 
-1. Open the predefined [Substrate API Sidecar](https://documenter.getpostman.com/view/24602305/2s8YsqWaj8#intro) API collection in a browser.
+1. Open the predefined [Substrate API Sidecar](https://documenter.getpostman.com/view/21393319/2sA3Qs9C9M#intro) API collection in a browser.
 2. Click **Run in Postman** in the top-right corner of the page.
 3. Select to run the collection either using Postman for Web or in the Postman for Mac desktop client.
 

--- a/content/md/en/homepage/get-started-homepage.md
+++ b/content/md/en/homepage/get-started-homepage.md
@@ -10,4 +10,6 @@ bodyLinkTwoTitle: Blockchain basics
 bodyLinkTwoURL: /learn/blockchain-basics/
 bodyLinkThreeTitle: Architecture and Rust libraries
 bodyLinkThreeURL: /learn/architecture/
+bodyLinkFourTitle:
+bodyLinkFourURL:
 ---

--- a/content/md/en/homepage/get-technical-homepage.md
+++ b/content/md/en/homepage/get-technical-homepage.md
@@ -10,4 +10,6 @@ bodyLinkTwoTitle: Rust for Substrate
 bodyLinkTwoURL:  /learn/rust-basics/
 bodyLinkThreeTitle: Command-line tools
 bodyLinkThreeURL: /reference/command-line-tools/
+bodyLinkFourTitle:
+bodyLinkFourURL:
 ---

--- a/content/md/en/homepage/hands-on-homepage.md
+++ b/content/md/en/homepage/hands-on-homepage.md
@@ -10,4 +10,6 @@ bodyLinkTwoTitle: Simulate a network
 bodyLinkTwoURL: /tutorials/build-a-blockchain/simulate-network/
 bodyLinkThreeTitle: Add a pallet
 bodyLinkThreeURL: /tutorials/build-application-logic/add-a-pallet/
+bodyLinkFourTitle:
+bodyLinkFourURL:
 ---

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -31,7 +31,7 @@ export default function Home({ data }) {
       <Section className="flex justify-center">
         <Card
           title="Polkadot SDK"
-          text="Polkadot SDK is now the overarching name for Substrate, and the rest of Polkadot's Development Kit"
+          text="Polkadot SDK is the overarching name for Substrate, and the rest of Polkadot's Development Kit."
           featured_image="/media/images/homepage/hands-on.png"
           link="/polkadot-sdk"
           bodyLinkOneURL="https://github.com/polkadot-developers/"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -57,26 +57,6 @@ export const query = graphql`
         }
       }
     }
-    goodbye: allMarkdownRemark(filter: { fileAbsolutePath: { regex: "/homepage/goodbye.md$/" } }) {
-      edges {
-        node {
-          id
-          frontmatter {
-            title
-            link
-            order
-            description
-            bodyLinkOneURL
-            bodyLinkOneTitle
-            bodyLinkTwoURL
-            bodyLinkTwoTitle
-            bodyLinkThreeURL
-            bodyLinkThreeTitle
-            featured_image
-          }
-        }
-      }
-    }
     content: allMarkdownRemark(filter: { fileAbsolutePath: { regex: "//(homepage)/" } }) {
       edges {
         node {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,26 +2,45 @@ import { graphql } from 'gatsby';
 import { Layout, Section, SEO } from 'gatsby-plugin-substrate';
 import React from 'react';
 
-import CardsList from '../components/layout/Documentation/CardList';
-import SearchDocumentation from '../components/ui/SearchDocumentation';
+import Card from '../components/layout/Documentation/Card';
+// import CardsList from '../components/layout/Documentation/CardList';
+// import SearchDocumentation from '../components/ui/SearchDocumentation';
 
 export default function Home({ data }) {
-  const { content } = data;
+  // eslint-disable-next-line no-empty-pattern
+  const {} = data;
   return (
     <Layout showFooterNewsletter={false} mode="full">
       <SEO title="Home" />
-      <Section className="text-center mt-12">
-        <h1 className="mb-8 text-4xl lg:text-6xl md:text-6xl font-title font-extrabold">Substrate Documentation</h1>
-        <div className="sm:max-w-lg mx-auto mb-10">
-          <p className="max-w-lg text-xl mx-auto">
-            Substrate documentation includes conceptual, procedural, and reference information for blockchain builders
-            and parachain project teams.
-          </p>
-        </div>
-        <SearchDocumentation />
+      <Section className="text-center mt-12 intro">
+        <h1 className="mb-8 text-4xl lg:text-6xl md:text-6xl font-title font-extrabold substrate">Substrate</h1>
+        <p>Is now part of </p>
+        <h1
+          className="
+          mb-8 text-4xl
+          lg:text-6xl
+          md:text-6xl
+          font-title
+          font-extrabold
+          polkadot-sdk
+          underline-effect"
+        >
+          Polkadot SDK
+        </h1>
       </Section>
       <Section className="flex justify-center">
-        <CardsList data={content.edges} />
+        <Card
+          title="Polkadot SDK"
+          text="Polkadot SDK is now the overarching name for Substrate, and the rest of Polkadot's Development Kit"
+          featured_image="/media/images/homepage/hands-on.png"
+          link="/polkadot-sdk"
+          bodyLinkOneURL="https://github.com/polkadot-developers/"
+          bodyLinkOneTitle="Polkadot Developers"
+          bodyLinkTwoURL="https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/index.html"
+          bodyLinkTwoTitle="Polkadot SDK Docs"
+          bodyLinkThreeURL="https://papermoonio.github.io/polkadot-ecosystem-docs-draft/"
+          bodyLinkThreeTitle="Polkadot Ecosystem Documentation"
+        />
       </Section>
     </Layout>
   );
@@ -35,6 +54,26 @@ export const query = graphql`
           ns
           data
           language
+        }
+      }
+    }
+    goodbye: allMarkdownRemark(filter: { fileAbsolutePath: { regex: "/homepage/goodbye.md$/" } }) {
+      edges {
+        node {
+          id
+          frontmatter {
+            title
+            link
+            order
+            description
+            bodyLinkOneURL
+            bodyLinkOneTitle
+            bodyLinkTwoURL
+            bodyLinkTwoTitle
+            bodyLinkThreeURL
+            bodyLinkThreeTitle
+            featured_image
+          }
         }
       }
     }

--- a/src/styles/scss/_home.scss
+++ b/src/styles/scss/_home.scss
@@ -135,6 +135,150 @@
   transition: 0.33s;
 }
 
+@import url('https://fonts.googleapis.com/css2?family=Unbounded:wght@200..900&display=swap');
+
+@keyframes wobbleFade {
+  0% {
+    transform: translate(0, 0) rotate(0deg);
+    opacity: 1;
+    text-shadow: 0px 5px 30px #24CC85;
+  }
+  5% {
+    transform: translate(-3px, -3px) rotate(-1deg);
+    opacity: 0.95;
+    text-shadow: 0px 5px 33px #24CC85;
+  }
+  10% {
+    transform: translate(3px, -3px) rotate(1deg);
+    opacity: 0.9;
+    text-shadow: 0px 5px 36px #24CC85;
+  }
+  15% {
+    transform: translate(-3px, 3px) rotate(-1deg);
+    opacity: 0.85;
+    text-shadow: 0px 5px 39px #24CC85;
+  }
+  20% {
+    transform: translate(3px, 3px) rotate(1deg);
+    opacity: 0.8;
+    text-shadow: 0px 5px 42px #24CC85;
+  }
+  25% {
+    transform: translate(-3px, -3px) rotate(-1deg);
+    opacity: 0.75;
+    text-shadow: 0px 5px 45px #24CC85;
+  }
+  30% {
+    transform: translate(3px, -3px) rotate(1deg);
+    opacity: 0.7;
+    text-shadow: 0px 5px 48px #24CC85;
+  }
+  35% {
+    transform: translate(-3px, 3px) rotate(-1deg);
+    opacity: 0.65;
+    text-shadow: 0px 5px 51px #24CC85;
+  }
+  40% {
+    transform: translate(3px, 3px) rotate(1deg);
+    opacity: 0.6;
+    text-shadow: 0px 5px 54px #24CC85;
+  }
+  45% {
+    transform: translate(-3px, -3px) rotate(-1deg);
+    opacity: 0.55;
+    text-shadow: 0px 5px 57px #24CC85;
+  }
+  50% {
+    transform: translate(3px, -3px) rotate(1deg);
+    opacity: 0.5;
+    text-shadow: 0px 5px 60px #24CC85;
+  }
+  55% {
+    transform: translate(-3px, 3px) rotate(-1deg);
+    opacity: 0.45;
+    text-shadow: 0px 5px 60px #24CC85;
+  }
+  60% {
+    transform: translate(3px, 3px) rotate(1deg);
+    opacity: 0.4;
+    text-shadow: 0px 5px 60px #24CC85;
+  }
+  65% {
+    transform: translate(-3px, -3px) rotate(-1deg);
+    opacity: 0.35;
+    text-shadow: 0px 5px 60px #24CC85;
+  }
+  70% {
+    transform: translate(3px, -3px) rotate(1deg);
+    opacity: 0.3;
+    text-shadow: 0px 5px 60px #24CC85;
+  }
+  75% {
+    transform: translate(-3px, 3px) rotate(-1deg);
+    opacity: 0.3;
+    text-shadow: 0px 5px 60px #24CC85;
+  }
+  80% {
+    transform: translate(3px, 3px) rotate(1deg);
+    opacity: 0.3;
+    text-shadow: 0px 5px 60px #24CC85;
+  }
+  85% {
+    transform: translate(-3px, -3px) rotate(-1deg);
+    opacity: 0.3;
+    text-shadow: 0px 5px 60px #24CC85;
+  }
+  90% {
+    transform: translate(3px, -3px) rotate(1deg);
+    opacity: 0.3;
+    text-shadow: 0px 5px 60px #24CC85;
+  }
+  95% {
+    transform: translate(-3px, 3px) rotate(-1deg);
+    opacity: 0.3;
+    text-shadow: 0px 5px 60px #24CC85;
+  }
+  100% {
+    transform: translate(0, 0) rotate(0deg);
+    opacity: 0.3; /* End at 0.3 opacity */
+    text-shadow: 0px 5px 60px #24CC85; /* End at 60px spread */
+  }
+}
+
+.substrate {
+  animation: wobbleFade 10s forwards; /* Use forwards to retain the final state */
+  text-shadow: 0px 5px 30px #24CC85;
+}
+
+.polkadot-sdk {
+  font-family: "Unbounded";
+}
+
+.underline-effect {
+  position: relative;
+  display: inline-block;
+  color: white; /* Base text color */
+}
+
+.underline-effect::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 5px; /* Thickness of the underline */
+  top: 60px;
+  bottom: 0;
+  left: 0;
+  background-color: #e6007a; /* Color of the underline */
+  transform: scaleX(0);
+  transform-origin: bottom right;
+  transition: transform 0.3s ease-out;
+}
+
+.underline-effect:hover::after {
+  transform: scaleX(1);
+  transform-origin: bottom left;
+}
+
 /* Hide scrollbar on windows */
 
 .nav-sidebar {
@@ -181,7 +325,7 @@ pre {
   margin: 1rem 0 2rem 0;
 }
 
-/* Code View */ 
+/* Code View */
 .markdown-body a.anchor {
   display:none;
 }

--- a/src/templates/single.js
+++ b/src/templates/single.js
@@ -107,12 +107,13 @@ export default function DocsSinglePage({ data, pageContext }) {
                 <main className="markdown-body">
                   {location.pathname !== '/polkadot-sdk' && (
                     <div className="deprecation">
-                      <strong>⚠️ Deprecation Notice:</strong>
+                      <strong>⚠️ Update Notice:</strong>
                       <p>
                         <i>
                           Please read <a href="/polkadot-sdk">Substrate to Polkadot SDK</a> page first.
                         </i>
                       </p>
+                      <hr></hr>
                     </div>
                   )}
                   <Markdown htmlAst={htmlAst} />

--- a/src/templates/single.js
+++ b/src/templates/single.js
@@ -1,3 +1,4 @@
+import { useLocation } from '@reach/router';
 import { graphql } from 'gatsby';
 import { Layout, Link, SEO } from 'gatsby-plugin-substrate';
 import React from 'react';
@@ -20,6 +21,8 @@ export default function DocsSinglePage({ data, pageContext }) {
   const { gitLogLatestDate } = data.markdownRemark.parent.fields != null ? data.markdownRemark.parent.fields : '';
   //const pagePathNoSlash = pagePath.endsWith('/') ? pagePath.slice(0, -1) : pagePath;
   const relativeFilePath = data.markdownRemark.parent.relativePath;
+  const location = useLocation(); // Get the current location
+
   function titleize(slug) {
     let words = slug.toLowerCase().replace(/-/g, ' ');
     words = words[0].toUpperCase() + words.substring(1);
@@ -102,6 +105,16 @@ export default function DocsSinglePage({ data, pageContext }) {
                   <h1>{title}</h1>
                 </header>
                 <main className="markdown-body">
+                  {location.pathname !== '/polkadot-sdk' && (
+                    <div className="deprecation">
+                      <strong>⚠️ Deprecation Notice:</strong>
+                      <p>
+                        <i>
+                          Please read <a href="/polkadot-sdk">Substrate to Polkadot SDK</a> page first.
+                        </i>
+                      </p>
+                    </div>
+                  )}
                   <Markdown htmlAst={htmlAst} />
                 </main>
               </div>

--- a/static/assets/quickstart/index.html
+++ b/static/assets/quickstart/index.html
@@ -20,36 +20,36 @@
       }
     </style>
   </head>
-  
+
   <body>
     <main role="main" class="container">
     <h1 style="font-family: sans-serif; font-weight: 500;">Display an account balance</h1>
       <p style="font-family: sans-serif;">Enter a development account address, then click <b>Get Balance</b>.</p>
-  
+
       <input type="text" size="58" id="account_address"/>
       <input type="button" onclick="GetBalance()" value="Get Balance">
       <p class="output">Balance: <span id="polkadot-balance">Not Connected</span></p>
     </main>
-  
+
     <script src="https://unpkg.com/@polkadot/util/bundle-polkadot-util.js"></script>
     <script src="https://unpkg.com/@polkadot/util-crypto/bundle-polkadot-util-crypto.js"></script>
     <script src="https://unpkg.com/@polkadot/types/bundle-polkadot-types.js"></script>
     <script src="https://unpkg.com/@polkadot/api/bundle-polkadot-api.js"></script>
-  
+
     <script>
       async function GetBalance() {
         const ADDR = '5Gb6Zfe8K8NSKrkFLCgqs8LUdk7wKweXM5pN296jVqDpdziR';
-  
+
         const { WsProvider, ApiPromise } = polkadotApi;
         const wsProvider = new WsProvider('ws://127.0.0.1:9944');
         const polkadot = await ApiPromise.create({ provider: wsProvider });
-  
+
         let polkadotBalance = document.getElementById("polkadot-balance");
         const x = document.getElementById("account_address").value;
         const { data: balance } = await polkadot.query.system.account(x);
-        
+
         polkadotBalance.innerText = balance.free;
-      }  
+      }
     </script>
   </body>
   </html>


### PR DESCRIPTION
This takes a big step towards deprecating a lot of the content here. 

Everything is still accessible, no URL has changed, but you would have to first see the deprecation page. 


The docs homepage now looks like this: 

<img width="1071" alt="Screenshot 2024-08-27 at 15 14 45" src="https://github.com/user-attachments/assets/03ad3e41-6edf-4855-9375-e961db48febd">

Once you click on it, you land on this page with further explanation, and access to all the old content in the navbar: 

<img width="1618" alt="Screenshot 2024-08-27 at 15 15 52" src="https://github.com/user-attachments/assets/c5ffa517-b6db-4915-a84d-904d6f461636">

And a single page looks like this: 

<img width="905" alt="Screenshot 2024-08-27 at 13 07 33" src="https://github.com/user-attachments/assets/e0f3f6ff-4ec6-45c2-9ed1-8994378ca76f">

- [ ] I need a counterpart PR in https://github.com/paritytech/substrate-website, that adds something to the top navbar, that links to the same `/polkadot-sdk` page. @rmnprkrl will you be able to help with that? 

