### PR TITLE
Changed polkadot sdk repo to substrate

### DIFF
--- a/content/md/en/docs/tutorials/build-application-logic/add-a-pallet.md
+++ b/content/md/en/docs/tutorials/build-application-logic/add-a-pallet.md
@@ -72,7 +72,7 @@ To add the dependencies for the Nicks pallet to the runtime:
    For example, add a line similar to the following:
 
    ```toml
-   pallet-nicks = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", branch = "polkadot-v1.0.0" }
+   pallet-nicks = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
    ```
 
    This line imports the `pallet-nicks` crate as a dependency and specifies the following:


### PR DESCRIPTION
Changed the Polkadot repository to Substrate, as the Nicks pallet is no longer available in the Polkadot repository.