### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
     <img alt="Substrate Logo" src="https://github.com/polkadot-developers/substrate-docs/raw/main/static/img/sub.gif" width="70%" />
   </a>
 </h1>
-<h1 align="center">Substrate Docs</h1>
-<h3 align="center">https://docs.substrate.io</h3>
+<h1 align="center">Substrate is now part of PolkadotSDK</h1>
+<h3 align="center">https://docs.polkadot.com/</h3>
 
 <!-- Badges -->
 
@@ -18,115 +18,18 @@
         <img style= "height: 30px" src="https://img.shields.io/static/v1?style=for-the-badge&logo=stackexchange&label=Substrate&message=Stack%20Exchange&color=green" /></a>
 	<br>
 	<br>
-    <a href="https://twitter.com/intent/follow?screen_name=substrate_io">
-        <img src="https://img.shields.io/twitter/follow/substrate_io?style=social&logo=twitter"
-            alt="follow on Twitter"></a>
+    <a href="https://x.com/polkadotdevs">
+        <img src="https://img.shields.io/twitter/follow/polkadotdevs?style=social&logo=twitter"
+            alt="follow on X"></a>
 </p>
 
-## Contributing
+## docs.substrate.io -> docs.polkadot.com
 
-Thank you for your interest in contributing to documentation for Substrate!
-As a member of the community, you are invited and encouraged to contribute by submitting issues, offering suggestions for improvements to existing content in the form of a pull request, adding review comments to existing pull requests and issues, proposing new content, or creating new pull requests to fix issues or provide new content.
+Thank you for your interest in the substrate documentation. As part of the new Polkadot Documentation Initiative, docs.substrate.io has been sunset, with all redirects leading to the new Polkadot Documentation found at docs.polkadot.com
 
-### Working with `/docs` content
+## This repository has been archived
 
-#### URL paths
+This repository has now been archived and the content frozen. If you'd like to contribute to the new Polkadot Documentation, please visit github.com/polkadot-developers/polkadot-docs to get involved. The old content will be kept for now in it's markdown form for you to view if you so wish.
 
-All `.md` files added to `./content/md/en/docs/` folder will output an URL path without the `/docs` prefix, eg.:
-
-- `index.md` for a category page : `./content/md/en/docs/reference/index.md` &rarr; `/reference/`
-- `<article-name>.md` for an article in its parent category `./content/md/en/docs/reference/glossary.md` &rarr; `/reference/glossary/`
-
-You can use any structure nesting needed, there is no limit of depth.
-
-#### Media / Images
-
-- use `./content/media/images/docs/` folder for images to be included in `/docs/*/*.md` files
-- source images in `.md`: `/media/images/docs/path/to/your/image/<image>.ext`
-
-#### Navigation config
-
-- update `./content/config/nav.yaml` to add or amend items and linking to your content
-  - an exception being `./content/md/en/docs/reference/how-to-guides/...` files that should _only_ be listed on the main how-to guide page in the index page for these pages: `./content/md/en/docs/reference/how-to-guides/index.md`, not to be included in the sidebar.
-
-This config file is used to generate sidebar menu where:
-
-- menu is populated from the `menu` sequence (respecting order)
-- menu supports three level hierarchy
-- menu accepts external links, eg.: `https://substrate.io`
-
-## Local Development
-
-### Install
-
-Navigate into your cloned local repo directory and install all dependencies.
-
-```shell
-# https://github.com/nvm-sh/nvm is suggested, so that you
-# switch to the correct version of node set in the .nvmrc file
-nvm i
-
-# Install dependencies
-yarn
-```
-
-**gatsby-plugin-substrate submodule**
-
-This website uses a submodule for shared components. To set it up please refer to the [gatsby-plugin-substrate repository](https://github.com/paritytech/gatsby-plugin-substrate#troubleshooting).
-
-```shell
-git submodule update --init --recursive
-```
-
-To update the submodule to the latest main branch, run:
-
-```shell
-git submodule update --remote
-```
-
-**Configure environment variables**
-
-Copy `example.env.development` into a new `.env.development` file.
-
-```shell
-cp example.env.development .env.development
-```
-
-Config URL variables based on your preferable local setup.
-URL will be used for links generation between Substrate websites.
-
-Default localhost port configuration:
-
-```env
-GATSBY_WEBSITE_URL=http://localhost:8100
-GATSBY_DOCS_URL=http://localhost:8200
-```
-
-**Start development server**
-
-Navigate into your new site’s directory and use the following command to start the development server locally.
-
-```shell
-yarn develop
-```
-
-**Troubleshooting**
-
-It is sometimes the case that gastby's cache gets corrupted when making changes.
-If you run into issues in local development, try to clean this and restart:
-
-```shell
-yarn clean
-yarn develop
-```
-
-## Security
-
-Please report _security_ bugs as stated in the [`static/security.txt` file](static/security.txt) in
-this repository.
-
-## License
-
-TBD, please open an issue to request any use outside of the official host https://docs.substrate.io/ at this time.
 
 <!-- Substrate **documentation** is license under the [Apache 2 license](./LICENSE). -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Thank you for your interest in the substrate documentation. As part of the new P
 
 ## This repository has been archived
 
-This repository has now been archived and the content frozen. If you'd like to contribute to the new Polkadot Documentation, please visit github.com/polkadot-developers/polkadot-docs to get involved. The old content will be kept for now in it's markdown form for you to view if you so wish.
+This repository has now been archived and the content frozen. If you'd like to contribute to the new Polkadot Documentation, please visit github.com/polkadot-developers/polkadot-docs to get involved. The old content will be kept for now in its markdown form for you to view if you so wish.
 
 
 <!-- Substrate **documentation** is license under the [Apache 2 license](./LICENSE). -->


### PR DESCRIPTION
We have sunset substrate.io & docs.substrate.io with all redirects now merged and leading to;

substrate.io --> Polkadot.com
docs.substrate.io --> docs.polkadot.com

I have kept this page simple and removed the contributing guidelines as we are now using the other repository, see below.

 - github.com/polkadot-developers/polkadot-docs

If there is any concerns / missing information, please feel free to comment and I can update this PR.